### PR TITLE
Undo/redo fix for Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>


### PR DESCRIPTION
Fix undo/redo behavior for Java 9+. This fix is based on https://github.com/nordfalk/jsyntaxpane/compare/master...jbfaden:master (also see https://github.com/nordfalk/jsyntaxpane/issues/198). Tested on Java 10 (build 10+46) on MacOS 10.13.3. Also update Maven compiler version for better error output.