### PR TITLE
Fix selection on token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # JSyntaxPaneTTx
 
-JSyntaxPaneTTx is a fork of [JSyntaxPane](https://code.google.com/archive/p/jsyntaxpane/) customized for use in the [Text Trix](https://github.com/the4thchild/texttrix) editor.
+JSyntaxPaneTTx is a fork of [JSyntaxPane](https://code.google.com/archive/p/jsyntaxpane/), a syntax highlighting library built in Java.
 
 Additional features in this fork include:
 
-* Support extended from Java 6 through 10
+* Support extended from Java 6 through 11
 * Customizable font size
 * Additional language support (just the basics so far): Perl, Nasal
-* Integration with Text Trix
+* Initially forked for use in the [Text Trix](https://github.com/the4thchild/texttrix) editor
 
-The JSyntaxPaneTTx library can be used in Text Trix or independently in other text editors for syntax highlighting.
+The JSyntaxPaneTTx library can be used independently in other Java-based text editors for syntax highlighting.
 
 ## Compile
 
 ### Dependencies
 
-* Java 6+ (mostly tested on Java 8-10)
+* JDK 6+ (mostly tested on 8-11)
 * Maven
 
 ### Build

--- a/src/main/java/jsyntaxpane/components/PairsMarker.java
+++ b/src/main/java/jsyntaxpane/components/PairsMarker.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2018 David Young david@textflex.com
+ * based on original file by
  * Copyright 2008 Ayman Al-Sairafi ayman.alsairafi@gmail.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
@@ -16,6 +18,8 @@ package jsyntaxpane.components;
 import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionListener;
 import jsyntaxpane.actions.*;
 import javax.swing.JEditorPane;
 import javax.swing.event.CaretEvent;
@@ -31,7 +35,8 @@ import jsyntaxpane.util.Configuration;
  *
  * @author Ayman Al-Sairafi
  */
-public class PairsMarker implements CaretListener, SyntaxComponent, PropertyChangeListener {
+public class PairsMarker implements CaretListener, SyntaxComponent, 
+		PropertyChangeListener, MouseMotionListener {
 
     public static final String PROPERTY_COLOR = "PairMarker.Color";
     private JTextComponent pane;
@@ -40,11 +45,33 @@ public class PairsMarker implements CaretListener, SyntaxComponent, PropertyChan
 
     public PairsMarker() {
     }
-
+    
+    /**
+     * Update marker after caret update.
+     * @param e caret event to find the caret position
+     */
     @Override
     public void caretUpdate(CaretEvent e) {
+        // will not fire until after mouse selection completed
+        markTokenAt(e.getDot());
+    }
+
+    /**
+     * Update marker at start of selection, which will remove any existing 
+     * marker there to avoid masking selection highlight by marker highlight.
+     * @param e mouse event, not used
+     */
+    @Override
+    public void mouseDragged(MouseEvent e) {
+        markTokenAt(pane.getSelectionStart());
+    }
+    
+    @Override
+    public void mouseMoved(MouseEvent e) {
+    }
+    
+    public void markTokenAt(int pos) {
         removeMarkers();
-        int pos = e.getDot();
         SyntaxDocument doc = ActionUtils.getSyntaxDocument(pane);
         Token token = doc.getTokenAt(pos);
         if (token != null && token.pairValue != 0) {
@@ -74,6 +101,7 @@ public class PairsMarker implements CaretListener, SyntaxComponent, PropertyChan
     public void install(JEditorPane editor) {
         pane = editor;
         pane.addCaretListener(this);
+        pane.addMouseMotionListener(this);
         status = Status.INSTALLING;
     }
 
@@ -81,6 +109,7 @@ public class PairsMarker implements CaretListener, SyntaxComponent, PropertyChan
     public void deinstall(JEditorPane editor) {
         status = Status.DEINSTALLING;
         pane.removeCaretListener(this);
+        pane.removeMouseMotionListener(this);
         removeMarkers();
     }
 
@@ -88,8 +117,10 @@ public class PairsMarker implements CaretListener, SyntaxComponent, PropertyChan
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("document")) {
                 pane.removeCaretListener(this);
+        		pane.removeMouseMotionListener(this);
             if (status.equals(Status.INSTALLING)) {
                 pane.addCaretListener(this);
+                pane.addMouseMotionListener(this);
                 removeMarkers();
             }
         }

--- a/src/main/java/jsyntaxpane/components/TokenMarker.java
+++ b/src/main/java/jsyntaxpane/components/TokenMarker.java
@@ -1,4 +1,6 @@
-/*
+/* 
+ * Copyright 2018 David Young david@textflex.com
+ * based on original file by
  * Copyright 2008 Ayman Al-Sairafi ayman.alsairafi@gmail.com
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
@@ -16,6 +18,8 @@ package jsyntaxpane.components;
 import java.beans.PropertyChangeEvent;
 import jsyntaxpane.actions.*;
 import java.awt.Color;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionListener;
 import java.beans.PropertyChangeListener;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -35,7 +39,8 @@ import jsyntaxpane.util.Configuration;
  * 
  * @author Ayman Al-Sairafi
  */
-public class TokenMarker implements SyntaxComponent, CaretListener, PropertyChangeListener {
+public class TokenMarker implements SyntaxComponent, CaretListener, 
+		PropertyChangeListener, MouseMotionListener {
 
     public static final String DEFAULT_TOKENTYPES = "IDENTIFIER, TYPE, TYPE2, TYPE3";
     public static final String PROPERTY_COLOR = "TokenMarker.Color";
@@ -52,11 +57,30 @@ public class TokenMarker implements SyntaxComponent, CaretListener, PropertyChan
     public TokenMarker() {
     }
 
+    /**
+     * Update token after caret update.
+     * @param e caret event to find the caret position
+     */
     @Override
     public void caretUpdate(CaretEvent e) {
+        // will not fire until after mouse selection completed
         markTokenAt(e.getDot());
     }
 
+    /**
+     * Update token at start of selection, which will remove any existing 
+     * token there to avoid masking selection highlight by token highlight.
+     * @param e mouse event, not used
+     */
+    @Override
+    public void mouseDragged(MouseEvent e) {
+        markTokenAt(pane.getSelectionStart());
+    }
+    
+    @Override
+    public void mouseMoved(MouseEvent e) {
+    }
+    
     public void markTokenAt(int pos) {
         SyntaxDocument doc = ActionUtils.getSyntaxDocument(pane);
         if (doc != null) {
@@ -121,6 +145,7 @@ public class TokenMarker implements SyntaxComponent, CaretListener, PropertyChan
     public void install(JEditorPane editor) {
         this.pane = editor;
         pane.addCaretListener(this);
+        pane.addMouseMotionListener(this);
         markTokenAt(editor.getCaretPosition());
         status = Status.INSTALLING;
     }

--- a/src/main/java/jsyntaxpane/components/TokenMarker.java
+++ b/src/main/java/jsyntaxpane/components/TokenMarker.java
@@ -155,6 +155,7 @@ public class TokenMarker implements SyntaxComponent, CaretListener,
         status = Status.DEINSTALLING;
         removeMarkers();
         pane.removeCaretListener(this);
+        pane.removeMouseMotionListener(this);
     }
     private static final Logger LOG = Logger.getLogger(TokenMarker.class.getName());
 
@@ -162,8 +163,10 @@ public class TokenMarker implements SyntaxComponent, CaretListener,
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("document")) {
                 pane.removeCaretListener(this);
+        		pane.removeMouseMotionListener(this);
             if (status.equals(Status.INSTALLING)) {
                 pane.addCaretListener(this);
+                pane.addMouseMotionListener(this);
                 removeMarkers();
             }
         }

--- a/src/main/resources/META-INF/services/jsyntaxpane/syntaxkits/xmlsyntaxkit/config.properties
+++ b/src/main/resources/META-INF/services/jsyntaxpane/syntaxkits/xmlsyntaxkit/config.properties
@@ -6,7 +6,7 @@ Action.toggle-comments.MenuText = Comment Block
 Action.toggle-comments.SmallIcon = comment.png
 Action.toggle-comments.MustHaveSelection = true
 Action.toggle-comments.Template = <!-- #{selection} -->
-Action.prettify = jsyntaxpane.actions.XmlPrettifyAction, control P
+Action.prettify = jsyntaxpane.actions.XmlPrettifyAction, control R
 Action.prettify.MenuText = Reformat XML
 Action.prettify.ToolTip = Reformat XML
 # The  XmlPrettifyAction takes these config parameters:


### PR DESCRIPTION
Make mouse selection visible when dragging over tokens. Also change the XML reformatting shortcut to Ctrl-R to avoid conflicting with Ctrl-P for line-up text navigation.